### PR TITLE
Added imagePullSecrets option to deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ The following tables lists the main configurable parameters of the `deephealth-f
 | `backend.clientId`  | OAuth Client ID that you can get registering the front-end at <backend-host>/backend/auth/applications/  | `nil`              |
 | `service.type`      | Kubernetes service type of the front-end                                                                 | `NodePort`         |
 | `ingress.enabled`   | Enable the ingress for the front-end service                                                             | `false`            |
-| `ingress.annations` | Annotations for the ingress related with the front-end service                                           | {}                 |
+| `ingress.annations` | Annotations for the ingress related with the front-end service                                           | `{}`               |
 | `ingress.hosts`     | Hosts paths for the ingress related with the front-end service (see example on `values.yaml`)            | `nil`              |
 | `image.repository`  | Front-end App Docker Image                                                                               | `dhealth/frontend` |
 | `image.tag`         | Front-end App Docker Image Tag                                                                           | `latest`           |
 | `image.pullPolicy`  | Pull policy for the front-end App Docker Image                                                           | `IfNotPresent`     |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                                         | `[]`               |
 | `replicaCount`      | Number of replicas of the the front-end server                                                           | `1`                |
 | `resources`         | CPU/Memory resource requests/limits of the front-end server replica                                      | `nil`              |
 | `nodeSelector`      | Node labels for pod assignment of the front-end server replicas                                          | `nil`              |

--- a/k8s/deephealth-frontend/templates/_helpers.tpl
+++ b/k8s/deephealth-frontend/templates/_helpers.tpl
@@ -25,3 +25,15 @@ Create chart name and version as used by the chart label.
 {{- define "deephealth-frontend.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "deephealth-frontend.imagePullSecrets" -}}
+  {{- if (not (empty .Values.image.pullSecrets)) }}
+imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/k8s/deephealth-frontend/templates/deployment.yaml
+++ b/k8s/deephealth-frontend/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/name: {{ include "deephealth-frontend.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- include "deephealth-frontend.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
When retrieving container images from private registries, it is
necessary to specify an image pull secret. This fix enables the frontend
Helm chart to manage pull secrets: users can put them into the
`.Values.image.pullSecrets` list, according to the Bitnami convention.